### PR TITLE
[WIP] Napari experiment (dont merge)

### DIFF
--- a/analysis_schema/ytDataClasses.py
+++ b/analysis_schema/ytDataClasses.py
@@ -35,9 +35,10 @@ class FieldNames(ytParameter):
 
     def _run(self):
         fieldname = super()._run()
-        if ',' in fieldname:
-            fieldtype, field = fieldname.split(',')
+        if "," in fieldname:
+            fieldtype, field = fieldname.split(",")
             return (fieldtype, field)
+
 
 class Sphere(ytDataObjectAbstract):
     """A sphere of points defined by a *center* and a *radius*.
@@ -130,13 +131,14 @@ class PhasePlot(ytBaseModel):
     Comments: Optional[str]
     _yt_operation: str = "PhasePlot"
 
+
 class NapariVolume(ytBaseModel):
-    ds: Dataset = Field(alias='Dataset')
-    field: FieldNames = Field(alias='Field')
+    ds: Dataset = Field(alias="Dataset")
+    field: FieldNames = Field(alias="Field")
     resolution: Optional[Tuple] = (100, 100, 100)
-    left_edge: Optional[Tuple] = (0., 0., 0.)
-    right_edge: Optional[Tuple] = (1., 1., 1.)
-    length_units: Optional[str] = 'code_length'
+    left_edge: Optional[Tuple] = (0.0, 0.0, 0.0)
+    right_edge: Optional[Tuple] = (1.0, 1.0, 1.0)
+    length_units: Optional[str] = "code_length"
     take_log: Optional[int] = 1
 
     def _run(self, napari=False):
@@ -147,16 +149,15 @@ class NapariVolume(ytBaseModel):
         else:
             return None
 
-
     def _get_ndarray(self):
         # first instantiate the dataset
         ds = self.ds._run()
 
         frb = ds.r[
-              self.left_edge[0]:self.right_edge[0]:complex(0, self.resolution[0]),
-              self.left_edge[1]:self.right_edge[1]:complex(0, self.resolution[1]),
-              self.left_edge[2]:self.right_edge[2]:complex(0, self.resolution[2]),
-              ]
+            self.left_edge[0] : self.right_edge[0] : complex(0, self.resolution[0]),
+            self.left_edge[1] : self.right_edge[1] : complex(0, self.resolution[1]),
+            self.left_edge[2] : self.right_edge[2] : complex(0, self.resolution[2]),
+        ]
 
         field = self.field._run()
 


### PR DESCRIPTION
This PR is an experiment for use with a napari plugin for loading a schema. It's a work in progress, mostly for discussion and testing purposes, so don't merge! 

The summary: 

This PR adds a schema property, `NapariVolume`, that returns a 3D fixed resolution sampling of a dataset. It is experimental mainly because the `NapariVolume` class is perhaps not necessary -- the napari plugin IO framework takes in a filepath (in this case a filepath to a validated json) and must return an image array. So it should be possible to construct a json from base yt commands rather than introducing this new class.

The actual napari plugin code is at [github.com/data-exp-lab/napari-ytschema ](github.com/data-exp-lab/napari-ytschema).