### PR TITLE
server json submission 

### DIFF
--- a/analysis_schema/index.html
+++ b/analysis_schema/index.html
@@ -12,10 +12,14 @@
 
 <!-- our main container with the monaco editor: -->
 <div id="container" style="width:800px;height:600px;border:1px solid grey"></div>
-<!-- a submit button that will take the current json and do something with it: -->
-<button id="submitbutton">Submit</button> 
-<!-- on submit, just copy the json text into another div for now:  -->
-<div id="results" style="width:800px;height:600px;border:1px solid grey"></div>
+
+<!-- our form that will submit the schema and return a new page with results -->
+<form id="schema_form" action="/run_schema" method="POST">
+    <input id="run_schema" type="hidden" name="json" value="">
+    <output name="schema_output" for="run_schema"></output>
+    <button id="submitbutton">Submit</button>
+</form>
+
 
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.17.0/min/vs/loader.js"></script>
@@ -53,9 +57,10 @@
 
         function submitJson() 
         {            
-            // pulls out the json text and does something with it. right now this just copies the 
-            // text into another div, but we could call a GET/POST method here with the json text
-            document.getElementById('results').innerHTML = editor.getValue()
+            // pulls out the json text and submits it via the schema_form
+            var json_to_submit = editor.getValue()
+            document.getElementById("run_schema").value = json_to_submit;
+            document.getElementById("schema_form").submit();
         }
         document.getElementById('submitbutton').onclick = submitJson; // update the func to call for button
         

--- a/analysis_schema/server.py
+++ b/analysis_schema/server.py
@@ -1,7 +1,9 @@
-# from .operations import Operation
 from .SchemaModel import schema
 import http.server
 import pkg_resources
+from cgi import parse_header, parse_multipart
+from urllib.parse import parse_qs
+import traceback
 
 # For static serving:
 # _index_contents = pkg_resources.resource_string(__name__, "index.html")
@@ -16,6 +18,7 @@ importScripts('https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.17.0/min/v
 """
 
 server_defaults = {"h": "localhost", "p": 8000, "schema_obj": "Plot"}
+
 
 class EditorHandler(http.server.BaseHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
@@ -34,6 +37,23 @@ class EditorHandler(http.server.BaseHTTPRequestHandler):
             return self.return_worker_proxy()
         self.send_response(404)
 
+    def parse_POST(self):
+        ctype, pdict = parse_header(self.headers["content-type"])
+        if ctype == "multipart/form-data":
+            postvars = parse_multipart(self.rfile, pdict)
+        elif ctype == "application/x-www-form-urlencoded":
+            length = int(self.headers["content-length"])
+            postvars = parse_qs(self.rfile.read(length), keep_blank_values=1)
+        else:
+            postvars = {}
+        return postvars
+
+    def do_POST(self):
+        if "/run_schema" in self.path:
+            postvars = self.parse_POST()
+            print("running schema")
+            return self.run_schema(postvars)
+
     def return_index(self):
         self.send_response(200)
         self.send_header("Content-type", "text/html")
@@ -43,8 +63,7 @@ class EditorHandler(http.server.BaseHTTPRequestHandler):
         return
 
     def return_schema(self):
-        """This function returns the schema generate within this module, which I am calling the defalut schema.
-        """
+        """This function returns the schema generate within this module, which I am calling the defalut schema."""
         self.send_response(200)
         self.send_header("Content-type", "application/json")
         self.end_headers()
@@ -52,13 +71,14 @@ class EditorHandler(http.server.BaseHTTPRequestHandler):
         return
 
     def return_external_schema(self):
-        """This function grabs a local schema file instead of generating the default schema. To change the file, change file name in `_json_contents` agruements. To change back to the default schema, change the call in `do_GET` under self.path to call return_schema.  
-        """
+        """This function grabs a local schema file instead of generating the default schema. To change the file, change file name in `_json_contents` agruements. To change back to the default schema, change the call in `do_GET` under self.path to call return_schema."""
         self.send_response(200)
         self.send_header("Content-type", "application/json")
         self.end_headers()
         # grabs the local file
-        _json_contents = pkg_resources.resource_string(__name__, "pydantic_schema.json")
+        _json_contents = pkg_resources.resource_string(
+            __name__, "yt_analysis_schema.json"
+        )
         self.wfile.write(_json_contents)
         return
 
@@ -69,22 +89,36 @@ class EditorHandler(http.server.BaseHTTPRequestHandler):
         self.wfile.write(_monaco_env)
         return
 
+    def run_schema(self, postvars: dict):
+        # the validated json is an argument in the path
+
+        json_str = postvars[b"json"][0].decode()
+        yt_results = run_a_schema(json_str)
+
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+
+        _index_contents = '<div id="results">' + yt_results + "</div>"
+
+        self.wfile.write(_index_contents.encode())
+
 
 class SchemaHTTPServer(http.server.HTTPServer):
-    def __init__(self, *args, **kwargs):        
+    def __init__(self, *args, **kwargs):
         self._schema_definition = schema.schema_json(indent=2)
         super().__init__(*args, **kwargs)
 
 
-def run(host = server_defaults["h"], port = server_defaults["p"], cli=False):
+def run(host=server_defaults["h"], port=server_defaults["p"], cli=False):
     """
-    run from command line using cli (see docstring in cli.py) or run from 
-    interactive shell with 
+    run from command line using cli (see docstring in cli.py) or run from
+    interactive shell with
 
     >>> from analysis_schema import server
     >>> server.run()
     """
-    
+
     server_address = (host, port)
     if cli is False:
         print(f"starting server at {host}:{port}")
@@ -92,3 +126,31 @@ def run(host = server_defaults["h"], port = server_defaults["p"], cli=False):
         print(f"crtl-c to kill server")
     httpd = SchemaHTTPServer(server_address, EditorHandler)
     httpd.serve_forever()
+
+
+def run_a_schema(json_payload_str):
+
+    # parse and validate
+    try:
+        valid_json = schema.parse_raw(json_payload_str)
+    except Exception as ex:
+        return "".join(
+            traceback.format_exception(etype=type(ex), value=ex, tb=ex.__traceback__)
+        )
+
+    # run it
+    try:
+        results = valid_json._run()
+    except Exception as ex:
+        return "".join(
+            traceback.format_exception(etype=type(ex), value=ex, tb=ex.__traceback__)
+        )
+
+    # convert results
+    html_results = []
+    for result in results:
+        if hasattr(result, "_repr_html_"):
+            html_results.append(result._repr_html_())
+        else:
+            html_results.append("<div> object does not have a _repr_html </div>")
+    return "".join(html_results)


### PR DESCRIPTION
This PR adds some infrastructure to the server for json submission. Two parts to it:

1. a html form that grabs the current value of the json from the editor
2. a POST method to process the json on the sever side. This method will call the `_run()` method for the pydantic-validated schema and then return `_repr_html_` attribute from the instantiated yt objects (if they exist).

This PR is mostly meant as a proof of concept for a browser-based schema experience. It's probably not worth further developing the server infrastructure as there are better tools to use if we want to develop a more fully featured web app, but this PR at least closes the loop and demonstrates the json validation working in the browser.