### PR TITLE
storing instantiated datasets, require field type

### DIFF
--- a/analysis_schema/_data_store.py
+++ b/analysis_schema/_data_store.py
@@ -1,0 +1,1 @@
+_instantiated_datasets = {}

--- a/analysis_schema/base_model.py
+++ b/analysis_schema/base_model.py
@@ -26,7 +26,7 @@ def show_plots(schema, files):
 class ytBaseModel(BaseModel):
     """
     A class to connect attributes and their values to yt operations and their
-    keywork arguements.
+    keyword arguments.
 
     Args:
         BaseModel ([type]): A pydantic basemodel in the form of a json schema

--- a/analysis_schema/data_classes.py
+++ b/analysis_schema/data_classes.py
@@ -33,7 +33,7 @@ class Dataset(ytBaseModel):
 
 class FieldNames(ytParameter):
     """
-    Specify a field name from the dataset
+    Specify a field name and field type from the dataset
     """
 
     # can't seeem to alias 'field' - maybe because the pydantic name 'Field' is called
@@ -51,9 +51,6 @@ class FieldNames(ytParameter):
 
 class Sphere(ytDataObjectAbstract):
     """A sphere of points defined by a *center* and a *radius*.
-
-    Args:
-        ytBaseModel ([type]): [description]
     """
 
     # found in the 'selection_data_containers.py'
@@ -64,10 +61,7 @@ class Sphere(ytDataObjectAbstract):
 
 
 class Region(ytDataObjectAbstract):
-    """summary
-
-    Args:
-        ytDataObjectAbstract ([type]): [description]
+    """A cartesian box data selection object
     """
 
     center: List[float]
@@ -77,12 +71,18 @@ class Region(ytDataObjectAbstract):
 
 
 class Slice(ytDataObjectAbstract):
+    """An axis-aligned 2-d slice data selection object
+    """
+
     axis: Union[int, str]
     coord: float
     _yt_operation: str = "slice"
 
 
 class SlicePlot(ytBaseModel):
+    """Axis-aligned slice plot.
+    """
+
     ds: Optional[Dataset] = Field(alias="Dataset")
     fields: FieldNames = Field(alias="FieldNames")
     normal: str = Field(alias="Axis")
@@ -99,6 +99,9 @@ class SlicePlot(ytBaseModel):
 
 
 class ProjectionPlot(ytBaseModel):
+    """Axis-aligned projection plot.
+    """
+
     ds: Optional[Dataset] = Field(alias="Dataset")
     fields: FieldNames = Field(alias="FieldNames")
     normal: Union[str, int] = Field(alias="Axis")
@@ -134,6 +137,9 @@ class ProjectionPlot(ytBaseModel):
 
 
 class PhasePlot(ytBaseModel):
+    """A yt phase plot
+    """
+
     data_source: Optional[Dataset] = Field(alias="Dataset")
     x_field: FieldNames = Field(alias="xField")
     y_field: FieldNames = Field(alias="yField")
@@ -155,10 +161,7 @@ class PhasePlot(ytBaseModel):
 class Visualizations(BaseModel):
     """
     This class organizes the attributes below so users can select the plot by name,
-    and see the correct arguments as suggestiongs
-
-    Args:
-        BaseModel (Pydantic BaseModel): [description]
+    and see the correct arguments as suggestions
     """
 
     # use pydantic basemodel

--- a/analysis_schema/data_classes.py
+++ b/analysis_schema/data_classes.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
+import yt
 from pydantic import BaseModel, Field
 
-from .base_model import ytBaseModel, ytDataObjectAbstract, ytParameter
 from ._data_store import _instantiated_datasets
-import yt
+from .base_model import ytBaseModel, ytDataObjectAbstract, ytParameter
 
 
 class Dataset(ytBaseModel):
@@ -101,17 +101,14 @@ class SlicePlot(ytBaseModel):
     data_source: Optional[DataSource3D] = Field(alias="DataSource")
     Comments: Optional[str]
     _yt_operation: str = "SlicePlot"
+    _known_kwargs: Optional[List[str]] = [
+        "data_source",
+    ]
 
     def _run(self):
         if self.ds is None:
             self.ds = list(_instantiated_datasets.values())[0]
         return super()._run()
-
-    @property
-    def axis(self):
-        # yt <= 4.1.0 uses axis instead of normal, this aliasing allows the
-        # recursive function to pull the right attribute.
-        return self.normal
 
 
 class ProjectionPlot(ytBaseModel):

--- a/analysis_schema/pydantic_schema_example.json
+++ b/analysis_schema/pydantic_schema_example.json
@@ -8,15 +8,16 @@
       {
         "ProjectionPlot": {
           "Axis":"y",
-          "Center": "m",
           "FieldNames": {
             "field": "temperature",
-            "field_type": "enzo"
+            "field_type": "gas"
           },
           "FontSize": 30,
           "DataSource":{
-            "Center": [0.6, 0.6, 0.6],
-            "Radius":0.2
+              "sphere": {
+                  "Center": [0.6, 0.6, 0.6],
+                  "Radius": 0.2
+              }
           }
         }
       }

--- a/analysis_schema/pydantic_schema_example.json
+++ b/analysis_schema/pydantic_schema_example.json
@@ -10,7 +10,8 @@
           "Axis":"y",
           "Center": "m",
           "FieldNames": {
-            "field": "temperature"
+            "field": "temperature",
+            "field_type": "enzo"
           },
           "FontSize": 30,
           "DataSource":{

--- a/analysis_schema/yt_analysis_schema.json
+++ b/analysis_schema/yt_analysis_schema.json
@@ -102,9 +102,55 @@
         "Radius"
       ]
     },
+    "Region": {
+      "title": "Region",
+      "description": "A cartesian box data selection object\n    ",
+      "type": "object",
+      "properties": {
+        "center": {
+          "title": "Center",
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "left_edge": {
+          "title": "Left Edge",
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "right_edge": {
+          "title": "Right Edge",
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        }
+      },
+      "required": [
+        "center",
+        "left_edge",
+        "right_edge"
+      ]
+    },
+    "DataSource3D": {
+      "title": "DataSource3D",
+      "description": "Select a subset of the dataset to visualize from the overall dataset",
+      "type": "object",
+      "properties": {
+        "sphere": {
+          "$ref": "#/definitions/Sphere"
+        },
+        "region": {
+          "$ref": "#/definitions/Region"
+        }
+      }
+    },
     "SlicePlot": {
       "title": "SlicePlot",
-      "description": "Axis-aligned slice plot.\n    ",
+      "description": "Axis-aligned slice plot.",
       "type": "object",
       "properties": {
         "Dataset": {
@@ -153,8 +199,8 @@
             }
           ]
         },
-        "data_source": {
-          "$ref": "#/definitions/Sphere"
+        "DataSource": {
+          "$ref": "#/definitions/DataSource3D"
         },
         "Comments": {
           "title": "Comments",
@@ -166,42 +212,9 @@
         "Axis"
       ]
     },
-    "Region": {
-      "title": "Region",
-      "description": "A cartesian box data selection object\n    ",
-      "type": "object",
-      "properties": {
-        "center": {
-          "title": "Center",
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
-        },
-        "left_edge": {
-          "title": "Left Edge",
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
-        },
-        "right_edge": {
-          "title": "Right Edge",
-          "type": "array",
-          "items": {
-            "type": "number"
-          }
-        }
-      },
-      "required": [
-        "center",
-        "left_edge",
-        "right_edge"
-      ]
-    },
     "ProjectionPlot": {
       "title": "ProjectionPlot",
-      "description": "Axis-aligned projection plot.\n    ",
+      "description": "Axis-aligned projection plot.",
       "type": "object",
       "properties": {
         "Dataset": {
@@ -279,24 +292,10 @@
           "type": "string"
         },
         "DataSource": {
-          "title": "Datasource",
-          "description": "Select a subset of the dataset to visualize from the overall dataset",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Sphere"
-            },
-            {
-              "$ref": "#/definitions/Region"
-            }
-          ]
+          "$ref": "#/definitions/DataSource3D"
         },
         "Comments": {
           "title": "Comments",
-          "type": "string"
-        },
-        "msg": {
-          "title": "Msg",
-          "default": "Select a subset of the dataset to visualize from the overall dataset",
           "type": "string"
         }
       },
@@ -307,7 +306,7 @@
     },
     "PhasePlot": {
       "title": "PhasePlot",
-      "description": "A yt phase plot\n    ",
+      "description": "A yt phase plot",
       "type": "object",
       "properties": {
         "Dataset": {

--- a/analysis_schema/yt_analysis_schema.json
+++ b/analysis_schema/yt_analysis_schema.json
@@ -1,6 +1,6 @@
 {
   "title": "yt Schema Model for Descriptive Visualization and Analysis",
-  "description": "Create a model in the form of a json schema, using the yt data classes. As values are added to the file referencing the schema, the function `run` with be called recursively to acccess nested yt elements and run the yt code.\n\nThe run function iterates through the attributes of the class and runs this values entered for those attributes and puts the output into a list. This list will be iterated through to render and display the output.",
+  "description": "Create a model in the form of a json schema, using the yt data classes. As values\nare added to the file referencing the schema, the function `run` with be called\nrecursively to acccess nested yt elements and run the yt code.\n\nThe run function iterates through the attributes of the class and runs this values\nentered for those attributes and puts the output into a list. This list will be\niterated through to render and display the output.",
   "type": "object",
   "properties": {
     "Data": {
@@ -17,12 +17,12 @@
   "definitions": {
     "Dataset": {
       "title": "Dataset",
-      "description": "The dataset to load. Filen name must be a string.\n\nRequired fields: Filename",
+      "description": "The dataset to load. Filename (fn) must be a string.\n\nRequired fields: Filename",
       "type": "object",
       "properties": {
         "FileName": {
           "title": "Filename",
-          "description": "Must be string containing the (path to the file and the) file name",
+          "description": "A string containing the (path to the file and the) file name",
           "type": "string",
           "format": "path"
         },
@@ -41,11 +41,15 @@
     },
     "FieldNames": {
       "title": "FieldNames",
-      "description": "Specify a field name from the dataset",
+      "description": "Specify a field name and field type from the dataset",
       "type": "object",
       "properties": {
         "field": {
           "title": "Field",
+          "type": "string"
+        },
+        "field_type": {
+          "title": "Field Type",
           "type": "string"
         },
         "comments": {
@@ -54,12 +58,13 @@
         }
       },
       "required": [
-        "field"
+        "field",
+        "field_type"
       ]
     },
     "Sphere": {
       "title": "Sphere",
-      "description": "A sphere of points defined by a *center* and a *radius*.\n\nArgs:\n    ytBaseModel ([type]): [description]",
+      "description": "A sphere of points defined by a *center* and a *radius*.\n    ",
       "type": "object",
       "properties": {
         "Center": {
@@ -99,7 +104,7 @@
     },
     "SlicePlot": {
       "title": "SlicePlot",
-      "description": "A class to connect attributes and their values to yt operations and their keywork arguements.\n\nArgs:\n    BaseModel ([type]): A pydantic basemodel in the form of a json schema\n\nRaises:\n    AttributeError: [description]\n\nReturns:\n    [list]: A list of yt classes to be run and then displayed",
+      "description": "Axis-aligned slice plot.\n    ",
       "type": "object",
       "properties": {
         "Dataset": {
@@ -163,7 +168,7 @@
     },
     "Region": {
       "title": "Region",
-      "description": "summary\n\nArgs:\n    ytDataObjectAbstract ([type]): [description]",
+      "description": "A cartesian box data selection object\n    ",
       "type": "object",
       "properties": {
         "center": {
@@ -196,7 +201,7 @@
     },
     "ProjectionPlot": {
       "title": "ProjectionPlot",
-      "description": "A class to connect attributes and their values to yt operations and their keywork arguements.\n\nArgs:\n    BaseModel ([type]): A pydantic basemodel in the form of a json schema\n\nRaises:\n    AttributeError: [description]\n\nReturns:\n    [list]: A list of yt classes to be run and then displayed",
+      "description": "Axis-aligned projection plot.\n    ",
       "type": "object",
       "properties": {
         "Dataset": {
@@ -288,6 +293,11 @@
         "Comments": {
           "title": "Comments",
           "type": "string"
+        },
+        "msg": {
+          "title": "Msg",
+          "default": "Select a subset of the dataset to visualize from the overall dataset",
+          "type": "string"
         }
       },
       "required": [
@@ -297,7 +307,7 @@
     },
     "PhasePlot": {
       "title": "PhasePlot",
-      "description": "A class to connect attributes and their values to yt operations and their keywork arguements.\n\nArgs:\n    BaseModel ([type]): A pydantic basemodel in the form of a json schema\n\nRaises:\n    AttributeError: [description]\n\nReturns:\n    [list]: A list of yt classes to be run and then displayed",
+      "description": "A yt phase plot\n    ",
       "type": "object",
       "properties": {
         "Dataset": {
@@ -377,7 +387,7 @@
     },
     "Visualizations": {
       "title": "Visualizations",
-      "description": "This class organizes the attributes below so users can select the plot by name, and see the correct arguments as suggestiongs\n\nArgs:\n    BaseModel (Pydantic BaseModel): [description]",
+      "description": "This class organizes the attributes below so users can select the plot by name,\nand see the correct arguments as suggestions",
       "type": "object",
       "properties": {
         "SlicePlot": {

--- a/scratch_notebooks/ytBaseModelPrototype.ipynb
+++ b/scratch_notebooks/ytBaseModelPrototype.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "active-butter",
    "metadata": {},
    "source": [
     "### a ytBaseModel pydantic class experiment\n",
@@ -20,7 +19,6 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "comprehensive-horizontal",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +93,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "velvet-australian",
    "metadata": {},
    "source": [
     "Now we'll create two new classes for `load` and `SlicePlot`:"
@@ -104,7 +101,6 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "gross-hamburg",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +117,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "strategic-trinity",
    "metadata": {},
    "source": [
     "now let's instantiate some classes:"
@@ -130,7 +125,6 @@
   {
    "cell_type": "code",
    "execution_count": 56,
-   "id": "animated-championship",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +134,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "labeled-jacket",
    "metadata": {},
    "source": [
     "so these objects are normal pydantic classes:"
@@ -149,7 +142,6 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "id": "colored-flour",
    "metadata": {},
    "outputs": [
     {
@@ -173,7 +165,6 @@
   {
    "cell_type": "code",
    "execution_count": 58,
-   "id": "armed-minnesota",
    "metadata": {},
    "outputs": [
     {
@@ -204,7 +195,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ongoing-arabic",
    "metadata": {},
    "source": [
     "but now we can use .run() to execute!"
@@ -213,7 +203,6 @@
   {
    "cell_type": "code",
    "execution_count": 59,
-   "id": "multiple-tablet",
    "metadata": {},
    "outputs": [
     {
@@ -258,7 +247,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "narrow-exhaust",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -266,7 +254,6 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "mathematical-password",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -357,7 +344,6 @@
   {
    "cell_type": "code",
    "execution_count": 60,
-   "id": "published-roommate",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +377,6 @@
   {
    "cell_type": "code",
    "execution_count": 65,
-   "id": "comic-disclosure",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -401,7 +386,6 @@
   {
    "cell_type": "code",
    "execution_count": 68,
-   "id": "funny-military",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,7 +395,6 @@
   {
    "cell_type": "code",
    "execution_count": 69,
-   "id": "indian-latter",
    "metadata": {},
    "outputs": [
     {
@@ -432,7 +415,6 @@
   {
    "cell_type": "code",
    "execution_count": 70,
-   "id": "western-knife",
    "metadata": {},
    "outputs": [
     {
@@ -456,7 +438,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "charged-tampa",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -464,7 +445,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "sunset-junior",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -486,7 +466,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/scratch_notebooks/ytBaseModelPrototype.ipynb
+++ b/scratch_notebooks/ytBaseModelPrototype.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "active-butter",
    "metadata": {},
    "source": [
     "### a ytBaseModel pydantic class experiment\n",
@@ -19,6 +20,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
+   "id": "comprehensive-horizontal",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,6 +95,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "velvet-australian",
    "metadata": {},
    "source": [
     "Now we'll create two new classes for `load` and `SlicePlot`:"
@@ -101,6 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
+   "id": "gross-hamburg",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,6 +121,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "strategic-trinity",
    "metadata": {},
    "source": [
     "now let's instantiate some classes:"
@@ -125,6 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": 56,
+   "id": "animated-championship",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,6 +140,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "labeled-jacket",
    "metadata": {},
    "source": [
     "so these objects are normal pydantic classes:"
@@ -142,6 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": 57,
+   "id": "colored-flour",
    "metadata": {},
    "outputs": [
     {
@@ -165,6 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": 58,
+   "id": "armed-minnesota",
    "metadata": {},
    "outputs": [
     {
@@ -195,6 +204,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ongoing-arabic",
    "metadata": {},
    "source": [
     "but now we can use .run() to execute!"
@@ -203,6 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": 59,
+   "id": "multiple-tablet",
    "metadata": {},
    "outputs": [
     {
@@ -247,6 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "narrow-exhaust",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -254,6 +266,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "mathematical-password",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,6 +357,7 @@
   {
    "cell_type": "code",
    "execution_count": 60,
+   "id": "published-roommate",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,6 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": 65,
+   "id": "comic-disclosure",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,6 +401,7 @@
   {
    "cell_type": "code",
    "execution_count": 68,
+   "id": "funny-military",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,6 +411,7 @@
   {
    "cell_type": "code",
    "execution_count": 69,
+   "id": "indian-latter",
    "metadata": {},
    "outputs": [
     {
@@ -415,6 +432,7 @@
   {
    "cell_type": "code",
    "execution_count": 70,
+   "id": "western-knife",
    "metadata": {},
    "outputs": [
     {
@@ -438,6 +456,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "charged-tampa",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -445,6 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "sunset-junior",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -466,7 +486,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,

--- a/tests/test_yt_dataset.py
+++ b/tests/test_yt_dataset.py
@@ -47,10 +47,40 @@ viz_only_prj = r"""
       {
         "ProjectionPlot": {
           "Axis":"y",
-          "Center": "m",
           "FieldNames": {
             "field": "temperature",
             "field_type": "gas"
+          },
+          "DataSource": {
+            "region": {
+              "center": [0.25, 0.25, 0.25],
+              "left_edge": [0.0, 0.0, 0.0],
+              "right_edge": [0.5, 0.5, 0.5]
+            }
+          }
+        }
+      }
+    ]
+}
+"""
+
+
+viz_only_slc = r"""
+{
+    "$schema": "./yt_analysis_schema.json",
+    "Plot": [
+      {
+        "ProjectionPlot": {
+          "Axis":"y",
+          "FieldNames": {
+            "field": "temperature",
+            "field_type": "gas"
+          },
+          "DataSource": {
+            "sphere": {
+              "Center": [0.25, 0.25, 0.25],
+              "Radius": 0.25
+            }
           }
         }
       }
@@ -71,7 +101,7 @@ def test_execution():
 
     # we can inject an instantiated dataset here! the methods that require a
     # ds will check the dataset store if ds is None and use this ds:
-    test_ds = fake_amr_ds(fields=["temperature"], units=["K"])
+    test_ds = fake_amr_ds(fields=[("gas", "temperature")], units=["K"])
     _instantiated_datasets["_test_ds"] = test_ds
 
     # run the slice plot

--- a/tests/test_ytschema.py
+++ b/tests/test_ytschema.py
@@ -1,9 +1,17 @@
+# isort: skip_file
 import json
+
 import yt
 from yt.testing import fake_amr_ds
+
 import analysis_schema
 from analysis_schema._data_store import _instantiated_datasets
-
+from analysis_schema.base_model import (
+    _check_run,
+    ytBaseModel,
+    ytDataObjectAbstract,
+    ytParameter,
+)
 
 ds_only = r"""
 {
@@ -12,30 +20,6 @@ ds_only = r"""
       "FileName": "IsolatedGalaxy/galaxy0030/galaxy0030",
       "DatasetName": "IG_Testing"
     }
-}
-"""
-
-
-viz_only_slc = r"""
-{
-    "$schema": "./yt_analysis_schema.json",
-    "Plot": [
-      {
-        "SlicePlot": {
-          "Axis":"y",
-          "Center": "m",
-          "FieldNames": {
-            "field": "temperature",
-            "field_type": "gas"
-          },
-          "FontSize": 30,
-          "DataSource":{
-            "Center": [0.6, 0.6, 0.6],
-            "Radius":0.2
-          }
-        }
-      }
-    ]
 }
 """
 
@@ -70,7 +54,7 @@ viz_only_slc = r"""
     "$schema": "./yt_analysis_schema.json",
     "Plot": [
       {
-        "ProjectionPlot": {
+        "SlicePlot": {
           "Axis":"y",
           "FieldNames": {
             "field": "temperature",
@@ -112,4 +96,12 @@ def test_execution():
     # run the projection plot
     model = analysis_schema.ytModel.parse_raw(viz_only_prj)
     m = model._run()
-    assert isinstance(m[0], yt.AxisAlignedProjectionPlot)
+    assert isinstance(m[0], yt.ProjectionPlot)
+
+
+def test_base_model():
+    # some basic tests of base_model
+    for cls in [ytBaseModel, ytDataObjectAbstract, ytParameter]:
+        c = cls()
+        assert _check_run(c)
+    assert _check_run("someothertype") is False


### PR DESCRIPTION
Three main changes in this PR:

1. I moved the dictionary that was storing the instantiated datasets to its own `_data_store` module, then adjusted how datasets are added to and pulled from the dictionary. This could perhaps use some more thought, but a dictionary seems to work OK for now...
2. I added `field_type` as a requirement for the `FieldNames` pydantic class, since yt will soon require it. Maybe `FieldNames` should be renamed to `FieldTuples`? 
3. I added an organizational class for `data_source` attributes in the slice and projection plots.

One of the nice side effects of the first change is that it makes it easy to test schema execution with in-memory datasets! See the updated `tests/test_yt_dataset.py`