### PR TITLE
run unit tests on pull request only

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
switches the unit tests (pytest) to run on pull request only (the other actions only run on pull request now as well). Closes #22 